### PR TITLE
Fix in-document anchor links

### DIFF
--- a/Sources/MarkdownRenderer.swift
+++ b/Sources/MarkdownRenderer.swift
@@ -549,8 +549,10 @@ enum MarkdownRenderer {
         slug = slug.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
         // Keep letters (Unicode), digits, hyphens, underscores, and whitespace; drop the rest.
         slug = slug.replacingOccurrences(of: "[^\\p{L}\\p{N}\\-_\\s]", with: "", options: .regularExpression)
-        // Collapse runs of whitespace into single hyphens.
-        slug = slug.replacingOccurrences(of: "\\s+", with: "-", options: .regularExpression)
+        // Replace each whitespace character with a hyphen individually. This matches GitHub's
+        // heading anchor algorithm: stripped punctuation that was surrounded by spaces leaves
+        // consecutive spaces that become consecutive hyphens, e.g. "Foo — Bar" → "foo--bar".
+        slug = slug.replacingOccurrences(of: "\\s", with: "-", options: .regularExpression)
         // Trim leading/trailing hyphens.
         slug = slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
         // Fallback if the heading was entirely punctuation.

--- a/Sources/WebView.swift
+++ b/Sources/WebView.swift
@@ -308,10 +308,11 @@ struct WebView: NSViewRepresentable {
             if navigationAction.navigationType == .linkActivated,
                let url = navigationAction.request.url {
                 // Same-document fragment links (`#heading-anchor`) — let WebKit
-                // handle the scroll natively. Detected when the URL has a
-                // fragment and otherwise matches the document's loaded URL.
+                // handle the scroll natively. Detected when the URL has a fragment
+                // and otherwise matches the document's loaded URL. `webView.url` can
+                // be nil right after `loadHTMLString`, so fall back to `baseURL`.
                 if url.fragment != nil,
-                   let current = webView.url,
+                   let current = webView.url ?? baseURL,
                    url.scheme == current.scheme,
                    url.host == current.host,
                    url.path == current.path {


### PR DESCRIPTION
Hi, I had an md file with internal links in it and noticed how that wasnt working inside readdown. I got claude to generate a quick fix, hope it helps! :) 

Markdown anchor links like [Section](#anchor) were silently failing to scroll because the slug generator used \s+ (one hyphen per run of whitespace), while GitHub converts each space to a hyphen individually.

When a heading such as "Intro to Programming — Spec Points" is processed, the em dash is stripped but its surrounding spaces are kept, leaving two consecutive spaces. GitHub's algorithm turns each of those into a hyphen, producing "intro-to-programming--spec-points". The app was collapsing them into one, producing "intro-to-programming-spec-points", so getElementById never found the element and no scroll occurred.

Fix: change \s+ to \s in uniqueSlug so each whitespace character maps to exactly one hyphen, matching GitHub's de facto convention.

Also tighten the same-document fragment check in the navigation delegate to fall back to baseURL when webView.url is nil (possible transiently after loadHTMLString), preventing fragment links being cancelled then.